### PR TITLE
Endrer objekt antallGrupper til antallElementer 

### DIFF
--- a/.github/workflows/deploy.dev.yml
+++ b/.github/workflows/deploy.dev.yml
@@ -2,7 +2,7 @@ name: Deploy dev
 
 on:
   push:
-    branches: paginering-identer
+    branches: master
 
 env:
   IMAGE: docker.pkg.github.com/${{ github.repository }}/dolly-backend:${{ github.sha }}

--- a/.github/workflows/deploy.dev.yml
+++ b/.github/workflows/deploy.dev.yml
@@ -2,7 +2,7 @@ name: Deploy dev
 
 on:
   push:
-    branches: master
+    branches: paginering-identer
 
 env:
   IMAGE: docker.pkg.github.com/${{ github.repository }}/dolly-backend:${{ github.sha }}

--- a/dolly-backend-app/src/main/java/no/nav/dolly/provider/api/TestgruppeController.java
+++ b/dolly-backend-app/src/main/java/no/nav/dolly/provider/api/TestgruppeController.java
@@ -116,7 +116,7 @@ public class TestgruppeController {
                 .pageNo(page.getNumber())
                 .antallPages(page.getTotalPages())
                 .pageSize(page.getPageable().getPageSize())
-                .antallGrupper(page.getTotalElements())
+                .antallElementer(page.getTotalElements())
                 .contents(mapperFacade.mapAsList(page.getContent(), RsTestgruppe.class))
                 .build();
     }

--- a/dolly-backend-domain/src/main/java/no/nav/dolly/domain/resultset/entity/testgruppe/RsTestgruppePage.java
+++ b/dolly-backend-domain/src/main/java/no/nav/dolly/domain/resultset/entity/testgruppe/RsTestgruppePage.java
@@ -1,14 +1,14 @@
 package no.nav.dolly.domain.resultset.entity.testgruppe;
 
-import static java.util.Objects.isNull;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Objects.isNull;
 
 @Data
 @Builder
@@ -19,7 +19,7 @@ public class RsTestgruppePage {
     private Integer antallPages;
     private Integer pageNo;
     private Integer pageSize;
-    private Long antallGrupper;
+    private Long antallElementer;
     private List<RsTestgruppe> contents;
 
     public List<RsTestgruppe> getContents() {


### PR DESCRIPTION
Slik at den kan behandles likt i frontend som TPSF paginerte identer, der returneres den også som antallElementer